### PR TITLE
#77 Replace ONAP png logo to svg logo

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,5 +1,5 @@
 project:
-  logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
+  logo_url: "https://github.com/crosscloudci/artwork/blob/master/ONAP/onap.svg"
   display_name: ONAP SO
   sub_title: Network Automation
   project_url: "https://github.com/onap/so"


### PR DESCRIPTION
https://github.com/crosscloudci/ci-dashboard/issues/77

Changes made: 
- logo_url: "https://github.com/crosscloudci/artwork/blob/master/ONAP/onap.svg"